### PR TITLE
docs: fix whitespace error in README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-# bash-parser-playground
+# bash-parser-playground
 
 [![Travis Build Status](https://img.shields.io/travis/vorpaljs/bash-parser-playground/master.svg)](http://travis-ci.org/vorpaljs/bash-parser-playground)
 [![NPM module](https://img.shields.io/npm/v/bash-parser-playground.svg)](https://npmjs.org/package/bash-parser-playground)


### PR DESCRIPTION
It looks like we accidentally added non-breaking space after the '#' in the
first line of the README. This corrects it to a regular space.